### PR TITLE
task-7: Authorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+package-lock.json
 .serverless
 coverage
 dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^18.2.0",
         "react-query": "^3.39.1",
         "react-router-dom": "^6.3.0",
+        "react-toastify": "^10.0.5",
         "yup": "^0.32.11"
       },
       "devDependencies": {
@@ -6310,6 +6311,26 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-toastify": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.5.tgz",
+      "integrity": "sha512-mNKt2jBXJg4O7pSdbNUfDdTsK9FIdikfsIE/yUCxbAEXl4HMyJaivrVFcn3Elvt5xvCQYhUZm+hqTIu1UXM3Pw==",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-toastify/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
@@ -11943,6 +11964,21 @@
       "requires": {
         "history": "^5.2.0",
         "react-router": "6.3.0"
+      }
+    },
+    "react-toastify": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.5.tgz",
+      "integrity": "sha512-mNKt2jBXJg4O7pSdbNUfDdTsK9FIdikfsIE/yUCxbAEXl4HMyJaivrVFcn3Elvt5xvCQYhUZm+hqTIu1UXM3Pw==",
+      "requires": {
+        "clsx": "^2.1.0"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+        }
       }
     },
     "react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-dom": "^18.2.0",
     "react-query": "^3.39.1",
     "react-router-dom": "^6.3.0",
+    "react-toastify": "^10.0.5",
     "yup": "^0.32.11"
   },
   "devDependencies": {

--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
-import axios from "axios";
+import axios, { AxiosRequestConfig } from "axios";
 
 type CSVFileImportProps = {
   url: string;
@@ -30,14 +30,22 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
       return;
     }
 
-    // Get the presigned URL
-    const response = await axios({
+    const headers: Record<string, string> = {};
+    const basicToken = localStorage.getItem("authorization_token");
+    if (basicToken) {
+      headers["Authorization"] = `Basic ${basicToken}`;
+    }
+    const requestConfig: AxiosRequestConfig = {
       method: "GET",
       url,
       params: {
         name: encodeURIComponent(file.name),
       },
-    });
+      headers: headers,
+    };
+
+    // Get the presigned URL
+    const response = await axios(requestConfig);
     console.log("File to upload: ", file.name);
     console.log("Uploading to (presigned url): ", response.data);
     const result = await fetch(response.data, {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,12 +7,27 @@ import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import { theme } from "~/theme";
+import { ToastContainer, toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+import axios from "axios";
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: { refetchOnWindowFocus: false, retry: false, staleTime: Infinity },
   },
 });
+
+axios.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const status = error.response?.status;
+    if (status === 401 || status === 403) {
+      const msg = status === 401 ? "Unauthorized. Please log in" : "Forbidden";
+      toast.error(`${status}: ${msg}`);
+    }
+    return Promise.reject(error);
+  }
+);
 
 if (import.meta.env.DEV) {
   const { worker } = await import("./mocks/browser");
@@ -27,6 +42,7 @@ root.render(
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
         <ThemeProvider theme={theme}>
+          <ToastContainer />
           <CssBaseline />
           <App />
         </ThemeProvider>


### PR DESCRIPTION
# task-7: Authorization
Cloudfront link: https://dewycxcozduah.cloudfront.net/
## Task 7.3
- [x] Client application is updated to send "Authorization: Basic authorization_token" header on import. Client gets authorization_token value from browser [localStorage]
## Additional task
- [x] Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior was added to the nodejs-aws-fe-main/src/index.tsx file.